### PR TITLE
Issue #6: Implement code for evaluating experiment configuration and bucketing users

### DIFF
--- a/fretboard/src/main/java/mozilla/components/service/fretboard/DeviceUuidFactory.kt
+++ b/fretboard/src/main/java/mozilla/components/service/fretboard/DeviceUuidFactory.kt
@@ -1,0 +1,29 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.service.fretboard
+
+import android.content.Context
+import java.util.UUID
+
+internal class DeviceUuidFactory(context: Context) {
+    val uuid by lazy {
+        val preferences = context
+            .getSharedPreferences(PREFS_FILE, Context.MODE_PRIVATE)
+        val prefUuid = preferences.getString(PREF_UUID_KEY, null)
+
+        if (prefUuid != null) {
+            UUID.fromString(prefUuid)
+        } else {
+            val uuid = UUID.randomUUID()
+            preferences.edit().putString(PREF_UUID_KEY, uuid.toString()).apply()
+            uuid
+        }
+    }
+
+    companion object {
+        private const val PREFS_FILE = "mozilla.components.service.fretboard"
+        private const val PREF_UUID_KEY = "device_uuid"
+    }
+}

--- a/fretboard/src/main/java/mozilla/components/service/fretboard/DeviceUuidFactory.kt
+++ b/fretboard/src/main/java/mozilla/components/service/fretboard/DeviceUuidFactory.kt
@@ -14,11 +14,11 @@ internal class DeviceUuidFactory(context: Context) {
         val prefUuid = preferences.getString(PREF_UUID_KEY, null)
 
         if (prefUuid != null) {
-            UUID.fromString(prefUuid)
+            UUID.fromString(prefUuid).toString()
         } else {
             val uuid = UUID.randomUUID()
             preferences.edit().putString(PREF_UUID_KEY, uuid.toString()).apply()
-            uuid
+            uuid.toString()
         }
     }
 

--- a/fretboard/src/main/java/mozilla/components/service/fretboard/Experiment.kt
+++ b/fretboard/src/main/java/mozilla/components/service/fretboard/Experiment.kt
@@ -20,7 +20,11 @@ data class Experiment(
     data class Matcher(
         val language: String? = null,
         val appId: String? = null,
-        val regions: List<String>? = null
+        val regions: List<String>? = null,
+        val version: String? = null,
+        val manufacturer: String? = null,
+        val device: String? = null,
+        val country: String? = null
     )
 
     data class Bucket(

--- a/fretboard/src/main/java/mozilla/components/service/fretboard/ExperimentDescriptor.kt
+++ b/fretboard/src/main/java/mozilla/components/service/fretboard/ExperimentDescriptor.kt
@@ -1,0 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.service.fretboard
+
+data class ExperimentDescriptor(val id: String)

--- a/fretboard/src/main/java/mozilla/components/service/fretboard/ExperimentEvaluator.kt
+++ b/fretboard/src/main/java/mozilla/components/service/fretboard/ExperimentEvaluator.kt
@@ -10,7 +10,7 @@ import android.text.TextUtils
 import java.util.Locale
 import java.util.zip.CRC32
 
-internal class ExperimentEvaluator {
+internal class ExperimentEvaluator(private val regionProvider: RegionProvider? = null) {
     fun evaluate(
         context: Context,
         experimentDescriptor: ExperimentDescriptor,
@@ -23,8 +23,9 @@ internal class ExperimentEvaluator {
 
     private fun matches(context: Context, experiment: Experiment): Boolean {
         if (experiment.match != null) {
-            val region = Locale.getDefault().isO3Country
-            val matchesRegion = !(experiment.match.regions != null &&
+            val region = regionProvider?.getRegion()
+            val matchesRegion = !(region != null &&
+                                        experiment.match.regions != null &&
                                         experiment.match.regions.isNotEmpty() &&
                                         experiment.match.regions.none { it == region })
             val appVersion = context.packageManager.getPackageInfo(context.packageName, 0).versionName

--- a/fretboard/src/main/java/mozilla/components/service/fretboard/ExperimentEvaluator.kt
+++ b/fretboard/src/main/java/mozilla/components/service/fretboard/ExperimentEvaluator.kt
@@ -53,7 +53,7 @@ internal class ExperimentEvaluator {
     }
 
     private fun getUserBucket(context: Context): Int {
-        val uuid = DeviceUuidFactory(context).uuid.toString()
+        val uuid = DeviceUuidFactory(context).uuid
         val crc = CRC32()
         crc.update(uuid.toByteArray())
         val checksum = crc.value

--- a/fretboard/src/main/java/mozilla/components/service/fretboard/ExperimentEvaluator.kt
+++ b/fretboard/src/main/java/mozilla/components/service/fretboard/ExperimentEvaluator.kt
@@ -1,0 +1,66 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.service.fretboard
+
+import android.content.Context
+import android.os.Build
+import android.text.TextUtils
+import java.util.Locale
+import java.util.zip.CRC32
+
+internal class ExperimentEvaluator {
+    fun evaluate(
+        context: Context,
+        experimentDescriptor: ExperimentDescriptor,
+        experiments: List<Experiment>,
+        userBucket: Int = getUserBucket(context)
+    ): Boolean {
+        val experiment = experiments.firstOrNull { it.id == experimentDescriptor.id } ?: return false
+        return isInBucket(userBucket, experiment) && matches(context, experiment)
+    }
+
+    private fun matches(context: Context, experiment: Experiment): Boolean {
+        if (experiment.match != null) {
+            val region = Locale.getDefault().isO3Country
+            val matchesRegion = !(experiment.match.regions != null &&
+                                        experiment.match.regions.isNotEmpty() &&
+                                        experiment.match.regions.none { it == region })
+            val appVersion = context.packageManager.getPackageInfo(context.packageName, 0).versionName
+            return matchesRegion &&
+                matchesExperiment(experiment.match.appId, context.packageName) &&
+                matchesExperiment(experiment.match.language, Locale.getDefault().isO3Language) &&
+                matchesExperiment(experiment.match.country, Locale.getDefault().isO3Country) &&
+                matchesExperiment(experiment.match.version, appVersion) &&
+                matchesExperiment(experiment.match.manufacturer, Build.MANUFACTURER) &&
+                matchesExperiment(experiment.match.device, Build.DEVICE)
+        }
+        return true
+    }
+
+    private fun matchesExperiment(experimentValue: String?, deviceValue: String): Boolean {
+        return !(experimentValue != null &&
+            !TextUtils.isEmpty(experimentValue) &&
+            !deviceValue.matches(experimentValue.toRegex()))
+    }
+
+    private fun isInBucket(userBucket: Int, experiment: Experiment): Boolean {
+        return !(experiment.bucket?.min == null ||
+            userBucket < experiment.bucket.min ||
+            experiment.bucket.max == null ||
+            userBucket >= experiment.bucket.max)
+    }
+
+    private fun getUserBucket(context: Context): Int {
+        val uuid = DeviceUuidFactory(context).uuid.toString()
+        val crc = CRC32()
+        crc.update(uuid.toByteArray())
+        val checksum = crc.value
+        return (checksum % MAX_BUCKET).toInt()
+    }
+
+    companion object {
+        private const val MAX_BUCKET = 100L
+    }
+}

--- a/fretboard/src/main/java/mozilla/components/service/fretboard/Fretboard.kt
+++ b/fretboard/src/main/java/mozilla/components/service/fretboard/Fretboard.kt
@@ -16,7 +16,6 @@ class Fretboard(
 ) {
     private var experiments: List<Experiment> = listOf()
     private var experimentsLoaded: Boolean = false
-    private val evaluator = ExperimentEvaluator()
 
     /**
      * Loads experiments from local storage

--- a/fretboard/src/main/java/mozilla/components/service/fretboard/Fretboard.kt
+++ b/fretboard/src/main/java/mozilla/components/service/fretboard/Fretboard.kt
@@ -16,6 +16,7 @@ class Fretboard(
 ) {
     private var experiments: List<Experiment> = listOf()
     private var experimentsLoaded: Boolean = false
+    private val evaluator = ExperimentEvaluator()
 
     /**
      * Loads experiments from local storage

--- a/fretboard/src/main/java/mozilla/components/service/fretboard/JSONExperimentParser.kt
+++ b/fretboard/src/main/java/mozilla/components/service/fretboard/JSONExperimentParser.kt
@@ -22,7 +22,14 @@ class JSONExperimentParser {
         val matchObject: JSONObject? = jsonObject.optJSONObject(MATCH_KEY)
         val regions: List<String>? = matchObject?.optJSONArray(REGIONS_KEY)?.toList()
         val matcher = if (matchObject != null) {
-            Experiment.Matcher(matchObject.tryGetString(LANG_KEY), matchObject.tryGetString(APP_ID_KEY), regions)
+            Experiment.Matcher(
+                matchObject.tryGetString(LANG_KEY),
+                matchObject.tryGetString(APP_ID_KEY),
+                regions,
+                matchObject.tryGetString(VERSION_KEY),
+                matchObject.tryGetString(MANUFACTURER_KEY),
+                matchObject.tryGetString(DEVICE_KEY),
+                matchObject.tryGetString(COUNTRY_KEY))
         } else null
         val bucket = if (bucketsObject != null) {
             Experiment.Bucket(bucketsObject.tryGetInt(MAX_KEY), bucketsObject.tryGetInt(MIN_KEY))
@@ -107,6 +114,10 @@ class JSONExperimentParser {
         private const val REGIONS_KEY = "regions"
         private const val LANG_KEY = "lang"
         private const val APP_ID_KEY = "appId"
+        private const val VERSION_KEY = "version"
+        private const val MANUFACTURER_KEY = "manufacturer"
+        private const val DEVICE_KEY = "device"
+        private const val COUNTRY_KEY = "country"
         private const val MAX_KEY = "max"
         private const val MIN_KEY = "min"
         private const val ID_KEY = "id"

--- a/fretboard/src/main/java/mozilla/components/service/fretboard/RegionProvider.kt
+++ b/fretboard/src/main/java/mozilla/components/service/fretboard/RegionProvider.kt
@@ -1,0 +1,19 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.service.fretboard
+
+/**
+ * Interface used to provide
+ * the user's region for evaluating
+ * experiments
+ */
+interface RegionProvider {
+    /**
+     * Provides the user's region
+     *
+     * @return user's region
+     */
+    fun getRegion(): String
+}

--- a/fretboard/src/test/java/mozilla/components/service/fretboard/DeviceUuidFactoryTest.kt
+++ b/fretboard/src/test/java/mozilla/components/service/fretboard/DeviceUuidFactoryTest.kt
@@ -1,0 +1,49 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.service.fretboard
+
+import android.content.Context
+import android.content.SharedPreferences
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.ArgumentMatchers
+import org.mockito.ArgumentMatchers.any
+import org.mockito.ArgumentMatchers.anyInt
+import org.mockito.ArgumentMatchers.anyString
+import org.mockito.ArgumentMatchers.eq
+import org.mockito.Mockito.`when`
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.verify
+import org.robolectric.RobolectricTestRunner
+import java.util.UUID
+
+@RunWith(RobolectricTestRunner::class)
+class DeviceUuidFactoryTest {
+    @Test
+    fun testUuidNoPreference() {
+        val context = mock(Context::class.java)
+        val sharedPreferences = mock(SharedPreferences::class.java)
+        val editor = mock(SharedPreferences.Editor::class.java)
+        `when`(editor.putString(anyString(), any())).thenReturn(editor)
+        `when`(sharedPreferences.edit()).thenReturn(editor)
+        `when`(sharedPreferences.getString(eq("device_uuid"), ArgumentMatchers.any())).thenReturn(null)
+        `when`(context.getSharedPreferences(anyString(), anyInt())).thenReturn(sharedPreferences)
+        val uuid = DeviceUuidFactory(context).uuid
+        assertTrue(uuid is UUID)
+        verify(editor).putString("device_uuid", uuid.toString())
+    }
+
+    @Test
+    fun testUuidSavedInPreferences() {
+        val savedUuid = "99111a0f-ca5d-4de1-913a-daba905c53b2"
+        val context = mock(Context::class.java)
+        val sharedPreferences = mock(SharedPreferences::class.java)
+        `when`(sharedPreferences.getString(eq("device_uuid"), any())).thenReturn(savedUuid)
+        `when`(context.getSharedPreferences(anyString(), anyInt())).thenReturn(sharedPreferences)
+        assertEquals(savedUuid, DeviceUuidFactory(context).uuid.toString())
+    }
+}

--- a/fretboard/src/test/java/mozilla/components/service/fretboard/DeviceUuidFactoryTest.kt
+++ b/fretboard/src/test/java/mozilla/components/service/fretboard/DeviceUuidFactoryTest.kt
@@ -7,7 +7,6 @@ package mozilla.components.service.fretboard
 import android.content.Context
 import android.content.SharedPreferences
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.ArgumentMatchers
@@ -19,7 +18,6 @@ import org.mockito.Mockito.`when`
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.verify
 import org.robolectric.RobolectricTestRunner
-import java.util.UUID
 
 @RunWith(RobolectricTestRunner::class)
 class DeviceUuidFactoryTest {
@@ -33,8 +31,7 @@ class DeviceUuidFactoryTest {
         `when`(sharedPreferences.getString(eq("device_uuid"), ArgumentMatchers.any())).thenReturn(null)
         `when`(context.getSharedPreferences(anyString(), anyInt())).thenReturn(sharedPreferences)
         val uuid = DeviceUuidFactory(context).uuid
-        assertTrue(uuid is UUID)
-        verify(editor).putString("device_uuid", uuid.toString())
+        verify(editor).putString("device_uuid", uuid)
     }
 
     @Test
@@ -44,6 +41,6 @@ class DeviceUuidFactoryTest {
         val sharedPreferences = mock(SharedPreferences::class.java)
         `when`(sharedPreferences.getString(eq("device_uuid"), any())).thenReturn(savedUuid)
         `when`(context.getSharedPreferences(anyString(), anyInt())).thenReturn(sharedPreferences)
-        assertEquals(savedUuid, DeviceUuidFactory(context).uuid.toString())
+        assertEquals(savedUuid, DeviceUuidFactory(context).uuid)
     }
 }

--- a/fretboard/src/test/java/mozilla/components/service/fretboard/ExperimentEvaluatorTest.kt
+++ b/fretboard/src/test/java/mozilla/components/service/fretboard/ExperimentEvaluatorTest.kt
@@ -371,27 +371,19 @@ class ExperimentEvaluatorTest {
         `when`(packageManager.getPackageInfo(anyString(), anyInt())).thenReturn(packageInfo)
         `when`(context.packageManager).thenReturn(packageManager)
 
-        val evaluator = ExperimentEvaluator()
+        var evaluator = ExperimentEvaluator(object : RegionProvider {
+            override fun getRegion(): String {
+                return "USA"
+            }
+        })
+
         assertTrue(evaluator.evaluate(context, ExperimentDescriptor("testid"), listOf(experiment), 20))
 
-        experiment = Experiment(
-            "testid",
-            "testexperiment",
-            "testdesc",
-            Experiment.Matcher(
-                "eng",
-                "test.appId",
-                listOf("GBR"),
-                "test.version",
-                "unknown",
-                "robolectric",
-                "USA"
-            ),
-            Experiment.Bucket(
-                70,
-                20
-            ),
-            1528916183)
+        evaluator = ExperimentEvaluator(object : RegionProvider {
+            override fun getRegion(): String {
+                return "ESP"
+            }
+        })
 
         assertFalse(evaluator.evaluate(context, ExperimentDescriptor("testid"), listOf(experiment), 20))
     }

--- a/fretboard/src/test/java/mozilla/components/service/fretboard/ExperimentEvaluatorTest.kt
+++ b/fretboard/src/test/java/mozilla/components/service/fretboard/ExperimentEvaluatorTest.kt
@@ -1,0 +1,406 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.service.fretboard
+
+import android.content.Context
+import android.content.pm.PackageInfo
+import android.content.pm.PackageManager
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.ArgumentMatchers.anyInt
+import org.mockito.ArgumentMatchers.anyString
+import org.mockito.Mockito.`when`
+import org.mockito.Mockito.mock
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class ExperimentEvaluatorTest {
+    @Test
+    fun testEvaluateBuckets() {
+        val experiment = Experiment(
+            "testid",
+            "testexperiment",
+            "testdesc",
+            Experiment.Matcher(
+                "eng",
+                "test.appId",
+                listOf("USA", "GBR"),
+                "test.version",
+                "unknown",
+                "robolectric",
+                "USA"
+            ),
+            Experiment.Bucket(
+                70,
+                20
+            ),
+            1528916183)
+
+        val context = mock(Context::class.java)
+        `when`(context.packageName).thenReturn("test.appId")
+        val packageManager = mock(PackageManager::class.java)
+        val packageInfo = PackageInfo()
+        packageInfo.versionName = "test.version"
+        `when`(packageManager.getPackageInfo(anyString(), anyInt())).thenReturn(packageInfo)
+        `when`(context.packageManager).thenReturn(packageManager)
+
+        val evaluator = ExperimentEvaluator()
+        assertTrue(evaluator.evaluate(context, ExperimentDescriptor("testid"), listOf(experiment), 20))
+        assertTrue(evaluator.evaluate(context, ExperimentDescriptor("testid"), listOf(experiment), 21))
+        assertTrue(evaluator.evaluate(context, ExperimentDescriptor("testid"), listOf(experiment), 69))
+        assertFalse(evaluator.evaluate(context, ExperimentDescriptor("testid"), listOf(experiment), 19))
+        assertFalse(evaluator.evaluate(context, ExperimentDescriptor("testid"), listOf(experiment), 70))
+        assertFalse(evaluator.evaluate(context, ExperimentDescriptor("testid"), listOf(experiment), 71))
+    }
+
+    @Test
+    fun testEvaluateAppId() {
+        val experiment = Experiment(
+            "testid",
+            "testexperiment",
+            "testdesc",
+            Experiment.Matcher(
+                "eng",
+                "^test$",
+                listOf("USA", "GBR"),
+                "test.version",
+                "unknown",
+                "robolectric",
+                "USA"
+            ),
+            Experiment.Bucket(
+                70,
+                20
+            ),
+            1528916183)
+
+        val context = mock(Context::class.java)
+        `when`(context.packageName).thenReturn("other.appId")
+        val packageManager = mock(PackageManager::class.java)
+        val packageInfo = PackageInfo()
+        packageInfo.versionName = "test.version"
+        `when`(packageManager.getPackageInfo(anyString(), anyInt())).thenReturn(packageInfo)
+        `when`(context.packageManager).thenReturn(packageManager)
+
+        val evaluator = ExperimentEvaluator()
+        assertFalse(evaluator.evaluate(context, ExperimentDescriptor("testid"), listOf(experiment), 20))
+        `when`(context.packageName).thenReturn("test")
+        assertTrue(evaluator.evaluate(context, ExperimentDescriptor("testid"), listOf(experiment), 20))
+    }
+
+    @Test
+    fun testEvaluateLanguage() {
+        var experiment = Experiment(
+            "testid",
+            "testexperiment",
+            "testdesc",
+            Experiment.Matcher(
+                "eng",
+                "test.appId",
+                listOf("USA", "GBR"),
+                "test.version",
+                "unknown",
+                "robolectric",
+                "USA"
+            ),
+            Experiment.Bucket(
+                70,
+                20
+            ),
+            1528916183)
+
+        val context = mock(Context::class.java)
+        `when`(context.packageName).thenReturn("test.appId")
+        val packageManager = mock(PackageManager::class.java)
+        val packageInfo = PackageInfo()
+        packageInfo.versionName = "test.version"
+        `when`(packageManager.getPackageInfo(anyString(), anyInt())).thenReturn(packageInfo)
+        `when`(context.packageManager).thenReturn(packageManager)
+
+        val evaluator = ExperimentEvaluator()
+        assertTrue(evaluator.evaluate(context, ExperimentDescriptor("testid"), listOf(experiment), 20))
+        experiment = Experiment(
+            "testid",
+            "testexperiment",
+            "testdesc",
+            Experiment.Matcher(
+                "esp",
+                "test.appId",
+                listOf("USA", "GBR"),
+                "test.version",
+                "unknown",
+                "robolectric",
+                "USA"
+            ),
+            Experiment.Bucket(
+                70,
+                20
+            ),
+            1528916183)
+        assertFalse(evaluator.evaluate(context, ExperimentDescriptor("testid"), listOf(experiment), 20))
+    }
+
+    @Test
+    fun testEvaluateCountry() {
+        var experiment = Experiment(
+            "testid",
+            "testexperiment",
+            "testdesc",
+            Experiment.Matcher(
+                "eng",
+                "test.appId",
+                listOf("USA", "GBR"),
+                "test.version",
+                "unknown",
+                "robolectric",
+                "USA"
+            ),
+            Experiment.Bucket(
+                70,
+                20
+            ),
+            1528916183)
+
+        val context = mock(Context::class.java)
+        `when`(context.packageName).thenReturn("test.appId")
+        val packageManager = mock(PackageManager::class.java)
+        val packageInfo = PackageInfo()
+        packageInfo.versionName = "test.version"
+        `when`(packageManager.getPackageInfo(anyString(), anyInt())).thenReturn(packageInfo)
+        `when`(context.packageManager).thenReturn(packageManager)
+
+        val evaluator = ExperimentEvaluator()
+        assertTrue(evaluator.evaluate(context, ExperimentDescriptor("testid"), listOf(experiment), 20))
+
+        experiment = Experiment(
+            "testid",
+            "testexperiment",
+            "testdesc",
+            Experiment.Matcher(
+                "eng",
+                "test.appId",
+                listOf("USA", "GBR"),
+                "test.version",
+                "unknown",
+                "robolectric",
+                "ESP"
+            ),
+            Experiment.Bucket(
+                70,
+                20
+            ),
+            1528916183)
+
+        assertFalse(evaluator.evaluate(context, ExperimentDescriptor("testid"), listOf(experiment), 20))
+    }
+
+    @Test
+    fun testEvaluateVersion() {
+        val experiment = Experiment(
+            "testid",
+            "testexperiment",
+            "testdesc",
+            Experiment.Matcher(
+                "eng",
+                "test.appId",
+                listOf("USA", "GBR"),
+                "test.version",
+                "unknown",
+                "robolectric",
+                "USA"
+            ),
+            Experiment.Bucket(
+                70,
+                20
+            ),
+            1528916183)
+
+        val context = mock(Context::class.java)
+        `when`(context.packageName).thenReturn("test.appId")
+        val packageManager = mock(PackageManager::class.java)
+        val packageInfo = PackageInfo()
+        packageInfo.versionName = "test.version"
+        `when`(packageManager.getPackageInfo(anyString(), anyInt())).thenReturn(packageInfo)
+        `when`(context.packageManager).thenReturn(packageManager)
+
+        val evaluator = ExperimentEvaluator()
+        assertTrue(evaluator.evaluate(context, ExperimentDescriptor("testid"), listOf(experiment), 20))
+
+        packageInfo.versionName = "other.version"
+        assertFalse(evaluator.evaluate(context, ExperimentDescriptor("testid"), listOf(experiment), 20))
+    }
+
+    @Test
+    fun testEvaluateDevice() {
+        var experiment = Experiment(
+            "testid",
+            "testexperiment",
+            "testdesc",
+            Experiment.Matcher(
+                "eng",
+                "test.appId",
+                listOf("USA", "GBR"),
+                "test.version",
+                "unknown",
+                "robolectric",
+                "USA"
+            ),
+            Experiment.Bucket(
+                70,
+                20
+            ),
+            1528916183)
+
+        val context = mock(Context::class.java)
+        `when`(context.packageName).thenReturn("test.appId")
+        val packageManager = mock(PackageManager::class.java)
+        val packageInfo = PackageInfo()
+        packageInfo.versionName = "test.version"
+        `when`(packageManager.getPackageInfo(anyString(), anyInt())).thenReturn(packageInfo)
+        `when`(context.packageManager).thenReturn(packageManager)
+
+        val evaluator = ExperimentEvaluator()
+        assertTrue(evaluator.evaluate(context, ExperimentDescriptor("testid"), listOf(experiment), 20))
+
+        experiment = Experiment(
+            "testid",
+            "testexperiment",
+            "testdesc",
+            Experiment.Matcher(
+                "eng",
+                "test.appId",
+                listOf("USA", "GBR"),
+                "test.version",
+                "unknown",
+                "otherdevice",
+                "USA"
+            ),
+            Experiment.Bucket(
+                70,
+                20
+            ),
+            1528916183)
+
+        assertFalse(evaluator.evaluate(context, ExperimentDescriptor("testid"), listOf(experiment), 20))
+    }
+
+    @Test
+    fun testEvaluateManufacturer() {
+        var experiment = Experiment(
+            "testid",
+            "testexperiment",
+            "testdesc",
+            Experiment.Matcher(
+                "eng",
+                "test.appId",
+                listOf("USA", "GBR"),
+                "test.version",
+                "unknown",
+                "robolectric",
+                "USA"
+            ),
+            Experiment.Bucket(
+                70,
+                20
+            ),
+            1528916183)
+
+        val context = mock(Context::class.java)
+        `when`(context.packageName).thenReturn("test.appId")
+        val packageManager = mock(PackageManager::class.java)
+        val packageInfo = PackageInfo()
+        packageInfo.versionName = "test.version"
+        `when`(packageManager.getPackageInfo(anyString(), anyInt())).thenReturn(packageInfo)
+        `when`(context.packageManager).thenReturn(packageManager)
+
+        val evaluator = ExperimentEvaluator()
+        assertTrue(evaluator.evaluate(context, ExperimentDescriptor("testid"), listOf(experiment), 20))
+
+        experiment = Experiment(
+            "testid",
+            "testexperiment",
+            "testdesc",
+            Experiment.Matcher(
+                "eng",
+                "test.appId",
+                listOf("USA", "GBR"),
+                "test.version",
+                "other",
+                "robolectric",
+                "USA"
+            ),
+            Experiment.Bucket(
+                70,
+                20
+            ),
+            1528916183)
+
+        assertFalse(evaluator.evaluate(context, ExperimentDescriptor("testid"), listOf(experiment), 20))
+    }
+
+    @Test
+    fun testEvaluateRegion() {
+        var experiment = Experiment(
+            "testid",
+            "testexperiment",
+            "testdesc",
+            Experiment.Matcher(
+                "eng",
+                "test.appId",
+                listOf("USA", "GBR"),
+                "test.version",
+                "unknown",
+                "robolectric",
+                "USA"
+            ),
+            Experiment.Bucket(
+                70,
+                20
+            ),
+            1528916183)
+
+        val context = mock(Context::class.java)
+        `when`(context.packageName).thenReturn("test.appId")
+        val packageManager = mock(PackageManager::class.java)
+        val packageInfo = PackageInfo()
+        packageInfo.versionName = "test.version"
+        `when`(packageManager.getPackageInfo(anyString(), anyInt())).thenReturn(packageInfo)
+        `when`(context.packageManager).thenReturn(packageManager)
+
+        val evaluator = ExperimentEvaluator()
+        assertTrue(evaluator.evaluate(context, ExperimentDescriptor("testid"), listOf(experiment), 20))
+
+        experiment = Experiment(
+            "testid",
+            "testexperiment",
+            "testdesc",
+            Experiment.Matcher(
+                "eng",
+                "test.appId",
+                listOf("GBR"),
+                "test.version",
+                "unknown",
+                "robolectric",
+                "USA"
+            ),
+            Experiment.Bucket(
+                70,
+                20
+            ),
+            1528916183)
+
+        assertFalse(evaluator.evaluate(context, ExperimentDescriptor("testid"), listOf(experiment), 20))
+    }
+
+    @Test
+    fun testEvaluateNoExperimentSameAsDescriptor() {
+        val savedExperiment = Experiment("wrongid")
+        val descriptor = ExperimentDescriptor("testid")
+        val context = mock(Context::class.java)
+        assertFalse(ExperimentEvaluator().evaluate(context, descriptor, listOf(savedExperiment), 20))
+    }
+}


### PR DESCRIPTION
This pull request introduces experiment evaluation and bucketing users. Experiment evaluation is done inside a class called `ExperimentEvaluator` and the user has to specify the experiment to evaluate using a new class called `ExperimentDescriptor`. 

`Fretboard` still doesn't have a public method to evaluate an experiment, I thought it would be better to create it as a separate pull request (since it's also a separate issue), but it would essentially call `ExperimentEvaluator` `evaluate` method.

There is also a class called `DeviceUuidFactory` which generates a random `UUID` for the device and saves it for later reuse, like the one on Fennec.

Closes #6