### PR TITLE
Issue #7: Implement simple API for checking if an installation is part of a specific experiment

### DIFF
--- a/fretboard/src/main/java/mozilla/components/service/fretboard/Fretboard.kt
+++ b/fretboard/src/main/java/mozilla/components/service/fretboard/Fretboard.kt
@@ -4,6 +4,8 @@
 
 package mozilla.components.service.fretboard
 
+import android.content.Context
+
 /**
  * Entry point of the library
  *
@@ -12,10 +14,12 @@ package mozilla.components.service.fretboard
  */
 class Fretboard(
     private val source: ExperimentSource,
-    private val storage: ExperimentStorage
+    private val storage: ExperimentStorage,
+    regionProvider: RegionProvider? = null
 ) {
     private var experiments: List<Experiment> = listOf()
     private var experimentsLoaded: Boolean = false
+    private val evaluator = ExperimentEvaluator(regionProvider)
 
     /**
      * Loads experiments from local storage
@@ -42,5 +46,18 @@ class Fretboard(
         } catch (e: ExperimentDownloadException) {
             // Keep using the local experiments
         }
+    }
+
+    /**
+     * Checks if the user is part of
+     * the specified experiment
+     *
+     * @param context context
+     * @param descriptor descriptor of the experiment to check
+     *
+     * @return true if the user is part of the specified experiment, false otherwise
+     */
+    fun isInExperiment(context: Context, descriptor: ExperimentDescriptor): Boolean {
+        return evaluator.evaluate(context, descriptor, experiments)
     }
 }


### PR DESCRIPTION
This pull request introduces the API for checking if a user is part of a specific experiment. Inside the `Fretboard` class there is a method called `isInExperiment` which returns true if the device is part of a specific experiment.

I spent some time thinking about the design of this API, mainly from the possible designs you mentioned on the issue, and then decided to go with this API because it felt simpler to me, and also because I think it improves Java interoperability, because on the other two the user would have to return null at the end of the lambda or create a `Function1` object if they're using Java 7.

Closes #7