### PR TITLE
Add a more Kotlin idiomatic method for checking experiments

### DIFF
--- a/fretboard/src/main/java/mozilla/components/service/fretboard/Fretboard.kt
+++ b/fretboard/src/main/java/mozilla/components/service/fretboard/Fretboard.kt
@@ -60,4 +60,17 @@ class Fretboard(
     fun isInExperiment(context: Context, descriptor: ExperimentDescriptor): Boolean {
         return evaluator.evaluate(context, descriptor, experiments)
     }
+
+    /**
+     * Performs an action if the user is part of the specified experiment
+     *
+     * @param context context
+     * @param descriptor descriptor of the experiment to check
+     * @param block block of code to be executed if the user is part of the experiment
+     */
+    fun withExperiment(context: Context, descriptor: ExperimentDescriptor, block: (Experiment) -> Unit) {
+        if (evaluator.evaluate(context, descriptor, experiments)) {
+            block(experiments.first { it.id == descriptor.id })
+        }
+    }
 }


### PR DESCRIPTION
This pull request adds a `withExperiment` method to the `Fretboard` class to make checking experiments more idiomatic to Kotlin.

I left the name unchanged because I think for me it looks good. Actually I think for me this API looks better than the other (`ExperimentDescriptor.ifActive`), because for this one we'll still need to pass the `Context` and the `Fretboard` object to it (correct me if I'm missing something). Also, let me know if you also want to add that additional function into this pull request (or if you prefer only the second one implemented).

Closes #29 