### PR TITLE
Issue #12: Implement simple API for getting experiment metadata 🔃

### DIFF
--- a/fretboard/src/main/java/mozilla/components/service/fretboard/Experiment.kt
+++ b/fretboard/src/main/java/mozilla/components/service/fretboard/Experiment.kt
@@ -15,7 +15,8 @@ data class Experiment(
     val description: String? = null,
     val match: Matcher? = null,
     val bucket: Bucket? = null,
-    val lastModified: Long? = null
+    val lastModified: Long? = null,
+    val payload: ExperimentPayload? = null
 ) {
     data class Matcher(
         val language: String? = null,

--- a/fretboard/src/main/java/mozilla/components/service/fretboard/ExperimentEvaluator.kt
+++ b/fretboard/src/main/java/mozilla/components/service/fretboard/ExperimentEvaluator.kt
@@ -16,9 +16,17 @@ internal class ExperimentEvaluator(private val regionProvider: RegionProvider? =
         experimentDescriptor: ExperimentDescriptor,
         experiments: List<Experiment>,
         userBucket: Int = getUserBucket(context)
-    ): Boolean {
-        val experiment = experiments.firstOrNull { it.id == experimentDescriptor.id } ?: return false
-        return isInBucket(userBucket, experiment) && matches(context, experiment)
+    ): Experiment? {
+        val experiment = getExperiment(experimentDescriptor, experiments) ?: return null
+        return if (isInBucket(userBucket, experiment) && matches(context, experiment)) {
+            experiment
+        } else {
+            null
+        }
+    }
+
+    fun getExperiment(descriptor: ExperimentDescriptor, experiments: List<Experiment>): Experiment? {
+        return experiments.firstOrNull { it.id == descriptor.id }
     }
 
     private fun matches(context: Context, experiment: Experiment): Boolean {

--- a/fretboard/src/main/java/mozilla/components/service/fretboard/ExperimentPayload.kt
+++ b/fretboard/src/main/java/mozilla/components/service/fretboard/ExperimentPayload.kt
@@ -1,0 +1,102 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.service.fretboard
+
+/**
+ * Class which represents an experiment associated data
+ */
+class ExperimentPayload {
+    private val valuesMap = HashMap<String, Any>()
+
+    /**
+     * Puts a value into the payload
+     *
+     * @param key key
+     * @param value value to put under the key
+     */
+    fun put(key: String, value: Any) {
+        valuesMap[key] = value
+    }
+
+    /**
+     * Gets a value from the payload
+     *
+     * @param key key
+     *
+     * @return value under the specified key
+     */
+    fun get(key: String): Any? {
+        return valuesMap[key]
+    }
+
+    /**
+     * Gets all the payload keys
+     *
+     * @return set of payload keys
+     */
+    fun getKeys(): Set<String> {
+        return valuesMap.keys.toSet()
+    }
+
+    /**
+     * Gets a value from the payload as a list of Boolean
+     *
+     * @param key key
+     *
+     * @return value under the specified key as a list of Boolean
+     */
+    @Suppress("UNCHECKED_CAST")
+    fun getBooleanList(key: String): List<Boolean>? {
+        return get(key) as List<Boolean>?
+    }
+
+    /**
+     * Gets a value from the payload as a list of Int
+     *
+     * @param key key
+     *
+     * @return value under the specified key as a list of Int
+     */
+    @Suppress("UNCHECKED_CAST")
+    fun getIntList(key: String): List<Int>? {
+        return get(key) as List<Int>?
+    }
+
+    /**
+     * Gets a value from the payload as a list of Long
+     *
+     * @param key key
+     *
+     * @return value under the specified key as a list of Long
+     */
+    @Suppress("UNCHECKED_CAST")
+    fun getLongList(key: String): List<Long>? {
+        return get(key) as List<Long>?
+    }
+
+    /**
+     * Gets a value from the payload as a list of Double
+     *
+     * @param key key
+     *
+     * @return value under the specified key as a list of Double
+     */
+    @Suppress("UNCHECKED_CAST")
+    fun getDoubleList(key: String): List<Double>? {
+        return get(key) as List<Double>?
+    }
+
+    /**
+     * Gets a value from the payload as a list of String
+     *
+     * @param key key
+     *
+     * @return value under the specified key as a list of String
+     */
+    @Suppress("UNCHECKED_CAST")
+    fun getStringList(key: String): List<String>? {
+        return get(key) as List<String>?
+    }
+}

--- a/fretboard/src/main/java/mozilla/components/service/fretboard/Fretboard.kt
+++ b/fretboard/src/main/java/mozilla/components/service/fretboard/Fretboard.kt
@@ -58,7 +58,7 @@ class Fretboard(
      * @return true if the user is part of the specified experiment, false otherwise
      */
     fun isInExperiment(context: Context, descriptor: ExperimentDescriptor): Boolean {
-        return evaluator.evaluate(context, descriptor, experiments)
+        return evaluator.evaluate(context, descriptor, experiments) != null
     }
 
     /**
@@ -69,8 +69,17 @@ class Fretboard(
      * @param block block of code to be executed if the user is part of the experiment
      */
     fun withExperiment(context: Context, descriptor: ExperimentDescriptor, block: (Experiment) -> Unit) {
-        if (evaluator.evaluate(context, descriptor, experiments)) {
-            block(experiments.first { it.id == descriptor.id })
-        }
+        evaluator.evaluate(context, descriptor, experiments)?.let { block(it) }
+    }
+
+    /**
+     * Gets the metadata associated with the specified experiment, even if the user is not part of it
+     *
+     * @param descriptor descriptor of the experiment
+     *
+     * @return metadata associated with the experiment
+     */
+    fun getExperiment(descriptor: ExperimentDescriptor): Experiment? {
+        return evaluator.getExperiment(descriptor, experiments)
     }
 }

--- a/fretboard/src/test/java/mozilla/components/service/fretboard/ExperimentEvaluatorTest.kt
+++ b/fretboard/src/test/java/mozilla/components/service/fretboard/ExperimentEvaluatorTest.kt
@@ -7,8 +7,8 @@ package mozilla.components.service.fretboard
 import android.content.Context
 import android.content.pm.PackageInfo
 import android.content.pm.PackageManager
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.ArgumentMatchers.anyInt
@@ -49,12 +49,12 @@ class ExperimentEvaluatorTest {
         `when`(context.packageManager).thenReturn(packageManager)
 
         val evaluator = ExperimentEvaluator()
-        assertTrue(evaluator.evaluate(context, ExperimentDescriptor("testid"), listOf(experiment), 20))
-        assertTrue(evaluator.evaluate(context, ExperimentDescriptor("testid"), listOf(experiment), 21))
-        assertTrue(evaluator.evaluate(context, ExperimentDescriptor("testid"), listOf(experiment), 69))
-        assertFalse(evaluator.evaluate(context, ExperimentDescriptor("testid"), listOf(experiment), 19))
-        assertFalse(evaluator.evaluate(context, ExperimentDescriptor("testid"), listOf(experiment), 70))
-        assertFalse(evaluator.evaluate(context, ExperimentDescriptor("testid"), listOf(experiment), 71))
+        assertNotNull(evaluator.evaluate(context, ExperimentDescriptor("testid"), listOf(experiment), 20))
+        assertNotNull(evaluator.evaluate(context, ExperimentDescriptor("testid"), listOf(experiment), 21))
+        assertNotNull(evaluator.evaluate(context, ExperimentDescriptor("testid"), listOf(experiment), 69))
+        assertNull(evaluator.evaluate(context, ExperimentDescriptor("testid"), listOf(experiment), 19))
+        assertNull(evaluator.evaluate(context, ExperimentDescriptor("testid"), listOf(experiment), 70))
+        assertNull(evaluator.evaluate(context, ExperimentDescriptor("testid"), listOf(experiment), 71))
     }
 
     @Test
@@ -87,9 +87,9 @@ class ExperimentEvaluatorTest {
         `when`(context.packageManager).thenReturn(packageManager)
 
         val evaluator = ExperimentEvaluator()
-        assertFalse(evaluator.evaluate(context, ExperimentDescriptor("testid"), listOf(experiment), 20))
+        assertNull(evaluator.evaluate(context, ExperimentDescriptor("testid"), listOf(experiment), 20))
         `when`(context.packageName).thenReturn("test")
-        assertTrue(evaluator.evaluate(context, ExperimentDescriptor("testid"), listOf(experiment), 20))
+        assertNotNull(evaluator.evaluate(context, ExperimentDescriptor("testid"), listOf(experiment), 20))
     }
 
     @Test
@@ -122,7 +122,7 @@ class ExperimentEvaluatorTest {
         `when`(context.packageManager).thenReturn(packageManager)
 
         val evaluator = ExperimentEvaluator()
-        assertTrue(evaluator.evaluate(context, ExperimentDescriptor("testid"), listOf(experiment), 20))
+        assertNotNull(evaluator.evaluate(context, ExperimentDescriptor("testid"), listOf(experiment), 20))
         experiment = Experiment(
             "testid",
             "testexperiment",
@@ -141,7 +141,7 @@ class ExperimentEvaluatorTest {
                 20
             ),
             1528916183)
-        assertFalse(evaluator.evaluate(context, ExperimentDescriptor("testid"), listOf(experiment), 20))
+        assertNull(evaluator.evaluate(context, ExperimentDescriptor("testid"), listOf(experiment), 20))
     }
 
     @Test
@@ -174,7 +174,7 @@ class ExperimentEvaluatorTest {
         `when`(context.packageManager).thenReturn(packageManager)
 
         val evaluator = ExperimentEvaluator()
-        assertTrue(evaluator.evaluate(context, ExperimentDescriptor("testid"), listOf(experiment), 20))
+        assertNotNull(evaluator.evaluate(context, ExperimentDescriptor("testid"), listOf(experiment), 20))
 
         experiment = Experiment(
             "testid",
@@ -195,7 +195,7 @@ class ExperimentEvaluatorTest {
             ),
             1528916183)
 
-        assertFalse(evaluator.evaluate(context, ExperimentDescriptor("testid"), listOf(experiment), 20))
+        assertNull(evaluator.evaluate(context, ExperimentDescriptor("testid"), listOf(experiment), 20))
     }
 
     @Test
@@ -228,10 +228,10 @@ class ExperimentEvaluatorTest {
         `when`(context.packageManager).thenReturn(packageManager)
 
         val evaluator = ExperimentEvaluator()
-        assertTrue(evaluator.evaluate(context, ExperimentDescriptor("testid"), listOf(experiment), 20))
+        assertNotNull(evaluator.evaluate(context, ExperimentDescriptor("testid"), listOf(experiment), 20))
 
         packageInfo.versionName = "other.version"
-        assertFalse(evaluator.evaluate(context, ExperimentDescriptor("testid"), listOf(experiment), 20))
+        assertNull(evaluator.evaluate(context, ExperimentDescriptor("testid"), listOf(experiment), 20))
     }
 
     @Test
@@ -264,7 +264,7 @@ class ExperimentEvaluatorTest {
         `when`(context.packageManager).thenReturn(packageManager)
 
         val evaluator = ExperimentEvaluator()
-        assertTrue(evaluator.evaluate(context, ExperimentDescriptor("testid"), listOf(experiment), 20))
+        assertNotNull(evaluator.evaluate(context, ExperimentDescriptor("testid"), listOf(experiment), 20))
 
         experiment = Experiment(
             "testid",
@@ -285,7 +285,7 @@ class ExperimentEvaluatorTest {
             ),
             1528916183)
 
-        assertFalse(evaluator.evaluate(context, ExperimentDescriptor("testid"), listOf(experiment), 20))
+        assertNull(evaluator.evaluate(context, ExperimentDescriptor("testid"), listOf(experiment), 20))
     }
 
     @Test
@@ -318,7 +318,7 @@ class ExperimentEvaluatorTest {
         `when`(context.packageManager).thenReturn(packageManager)
 
         val evaluator = ExperimentEvaluator()
-        assertTrue(evaluator.evaluate(context, ExperimentDescriptor("testid"), listOf(experiment), 20))
+        assertNotNull(evaluator.evaluate(context, ExperimentDescriptor("testid"), listOf(experiment), 20))
 
         experiment = Experiment(
             "testid",
@@ -339,7 +339,7 @@ class ExperimentEvaluatorTest {
             ),
             1528916183)
 
-        assertFalse(evaluator.evaluate(context, ExperimentDescriptor("testid"), listOf(experiment), 20))
+        assertNull(evaluator.evaluate(context, ExperimentDescriptor("testid"), listOf(experiment), 20))
     }
 
     @Test
@@ -377,7 +377,7 @@ class ExperimentEvaluatorTest {
             }
         })
 
-        assertTrue(evaluator.evaluate(context, ExperimentDescriptor("testid"), listOf(experiment), 20))
+        assertNotNull(evaluator.evaluate(context, ExperimentDescriptor("testid"), listOf(experiment), 20))
 
         evaluator = ExperimentEvaluator(object : RegionProvider {
             override fun getRegion(): String {
@@ -385,7 +385,7 @@ class ExperimentEvaluatorTest {
             }
         })
 
-        assertFalse(evaluator.evaluate(context, ExperimentDescriptor("testid"), listOf(experiment), 20))
+        assertNull(evaluator.evaluate(context, ExperimentDescriptor("testid"), listOf(experiment), 20))
     }
 
     @Test
@@ -393,6 +393,6 @@ class ExperimentEvaluatorTest {
         val savedExperiment = Experiment("wrongid")
         val descriptor = ExperimentDescriptor("testid")
         val context = mock(Context::class.java)
-        assertFalse(ExperimentEvaluator().evaluate(context, descriptor, listOf(savedExperiment), 20))
+        assertNull(ExperimentEvaluator().evaluate(context, descriptor, listOf(savedExperiment), 20))
     }
 }

--- a/fretboard/src/test/java/mozilla/components/service/fretboard/JSONExperimentParserTest.kt
+++ b/fretboard/src/test/java/mozilla/components/service/fretboard/JSONExperimentParserTest.kt
@@ -56,4 +56,28 @@ class JSONExperimentParserTest {
         assertEquals(Experiment("sample-id", bucket = Experiment.Bucket(), match = Experiment.Matcher()),
             JSONExperimentParser().fromJson(JSONObject(emptyObjects)))
     }
+
+    @Test
+    fun testPayloadFromJson() {
+        val json = """{"buckets":null,"name":null,"match":null,"description":null,"id":"sample-id","last_modified":null,"payload":{"a":"a","b":3,"c":3.5,"d":true,"e":[1,2,3,4]}}"""
+        val experiment = JSONExperimentParser().fromJson(JSONObject(json))
+        assertEquals("a", experiment.payload?.get("a"))
+        assertEquals(3, experiment.payload?.get("b"))
+        assertEquals(3.5, experiment.payload?.get("c"))
+        assertEquals(true, experiment.payload?.get("d"))
+        assertEquals(listOf(1, 2, 3, 4), experiment.payload?.getIntList("e"))
+    }
+
+    @Test
+    fun testPayloadToJson() {
+        val payload = ExperimentPayload()
+        payload.put("a", "a")
+        payload.put("b", 3)
+        payload.put("c", 3.5)
+        payload.put("d", true)
+        payload.put("e", listOf(1, 2, 3, 4))
+        val experiment = Experiment("id", payload = payload)
+        val json = JSONExperimentParser().toJson(experiment)
+        assertEquals("""{"payload":{"a":"a","b":3,"c":3.5,"d":true,"e":[1,2,3,4]},"buckets":{},"match":{},"id":"id"}""", json.toString())
+    }
 }


### PR DESCRIPTION
This pull request introduces a simple API (`getExperiment`)  which completes the Java-style API `isInExperiment` and allows to get an experiment associated metadata. In addition to that it includes the mechanisms for storing payload data inside the experiment and loading it from JSON.

The `Experiment` class now has a `payload` property which contains its associated metadata. I thought it would be better to abstract it from the `JSONObject` from which it comes from, so I created a class called `ExperimentPayload` which allows to retrieve those values by key.

Also, I refactored the `evaluate` method of `ExperimentEvaluator` class to make it return an `Experiment` in order to avoid repeating the same code for getting an experiment by its descriptor multiple times

Closes #12