### PR TITLE
Use latest android-components Docker image.

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -27,14 +27,14 @@ tasks:
     payload:
       maxRunTime: 3600
       deadline: "{{ '2 hours' | $fromNow }}"
-      image: 'mozillamobile/android-components:1.1'
+      image: 'mozillamobile/android-components:1.4'
       command:
         - /bin/bash
         - '--login'
         - '-cx'
         - >-
-          mkdir -p /opt/fretboard
-          && cd /opt/fretboard
+          mkdir -p /build/fretboard
+          && cd /build/fretboard
           && git clone {{ event.head.repo.url }}
           && cd fretboard
           && git config advice.detachedHead false


### PR DESCRIPTION
This should resolve the random build failures on taskcluster (especially when multiple builds run in parallel).