### PR TITLE
Issue #32: JSONExperimentParserTest is not deterministic

### DIFF
--- a/fretboard-storage-flatfile/src/androidTest/java/mozilla/components/service/fretboard/storage/atomicfile/AtomicFileExperimentStorageTest.kt
+++ b/fretboard-storage-flatfile/src/androidTest/java/mozilla/components/service/fretboard/storage/atomicfile/AtomicFileExperimentStorageTest.kt
@@ -8,6 +8,7 @@ import android.support.test.InstrumentationRegistry
 import android.support.test.runner.AndroidJUnit4
 import android.util.AtomicFile
 import mozilla.components.service.fretboard.Experiment
+import org.json.JSONObject
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Assert.assertEquals
@@ -31,7 +32,24 @@ class AtomicFileExperimentStorageTest {
         assertFalse(atomicFile.baseFile.exists())
         AtomicFileExperimentStorage(atomicFile).save(experiments)
         assertTrue(atomicFile.baseFile.exists())
-        assertEquals("""{"experiments":[{"name":"sample-name","match":{"lang":"es|en","appId":"sample-appId","regions":["US"]},"buckets":{"max":20,"min":0},"description":"sample-description","id":"sample-id","last_modified":1526991669}]}""", String(atomicFile.readFully()))
+        val experimentsJson = JSONObject(String(atomicFile.readFully()))
+        assertEquals(1, experimentsJson.length())
+        val experimentsJsonArray = experimentsJson.getJSONArray("experiments")
+        assertEquals(1, experimentsJsonArray.length())
+        val experimentJson = experimentsJsonArray[0] as JSONObject
+        assertEquals("sample-name", experimentJson.getString("name"))
+        val experimentMatch = experimentJson.getJSONObject("match")
+        assertEquals("es|en", experimentMatch.getString("lang"))
+        assertEquals("sample-appId", experimentMatch.getString("appId"))
+        val experimentRegions = experimentMatch.getJSONArray("regions")
+        assertEquals(1, experimentRegions.length())
+        assertEquals("US", experimentRegions[0])
+        val experimentBuckets = experimentJson.getJSONObject("buckets")
+        assertEquals(20, experimentBuckets.getInt("max"))
+        assertEquals(0, experimentBuckets.getInt("min"))
+        assertEquals("sample-description", experimentJson.getString("description"))
+        assertEquals("sample-id", experimentJson.getString("id"))
+        assertEquals(1526991669, experimentJson.getLong("last_modified"))
         atomicFile.delete()
     }
 

--- a/fretboard-storage-flatfile/src/test/java/mozilla/components/service/fretboard/storage/atomicfile/ExperimentsSerializerTest.kt
+++ b/fretboard-storage-flatfile/src/test/java/mozilla/components/service/fretboard/storage/atomicfile/ExperimentsSerializerTest.kt
@@ -6,6 +6,7 @@ package mozilla.components.service.fretboard.storage.atomicfile
 
 import mozilla.components.service.fretboard.Experiment
 import org.json.JSONException
+import org.json.JSONObject
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -107,12 +108,47 @@ class ExperimentsSerializerTest {
                 Experiment.Bucket(10, 5),
                 1523549895749)
         )
-        assertEquals(experimentsJson.replace("\\s+".toRegex(), ""), ExperimentsSerializer().toJson(experiments))
+        val json = JSONObject(ExperimentsSerializer().toJson(experiments))
+        assertEquals(1, json.length())
+        val experimentsArray = json.getJSONArray("experiments")
+        assertEquals(2, experimentsArray.length())
+        val firstExperiment = experimentsArray[0] as JSONObject
+        val firstExperimentBuckets = firstExperiment.getJSONObject("buckets")
+        assertEquals(0, firstExperimentBuckets.getInt("min"))
+        assertEquals(100, firstExperimentBuckets.getInt("max"))
+        assertEquals("first", firstExperiment.getString("name"))
+        val firstExperimentMatch = firstExperiment.getJSONObject("match")
+        val firstExperimentRegions = firstExperimentMatch.getJSONArray("regions")
+        assertEquals(1, firstExperimentRegions.length())
+        assertEquals("esp", firstExperimentRegions[0])
+        assertEquals("^org.mozilla.firefox_beta${'$'}", firstExperimentMatch.getString("appId"))
+        assertEquals("eng|es|deu|fra", firstExperimentMatch.getString("lang"))
+        assertEquals("Description", firstExperiment.getString("description"))
+        assertEquals("experiment-id", firstExperiment.getString("id"))
+        assertEquals(1523549895713, firstExperiment.getLong("last_modified"))
+
+        val secondExperiment = experimentsArray[1] as JSONObject
+        val secondExperimentBuckets = secondExperiment.getJSONObject("buckets")
+        assertEquals(5, secondExperimentBuckets.getInt("min"))
+        assertEquals(10, secondExperimentBuckets.getInt("max"))
+        assertEquals("second", secondExperiment.getString("name"))
+        val secondExperimentMatch = secondExperiment.getJSONObject("match")
+        val secondExperimentRegions = secondExperimentMatch.getJSONArray("regions")
+        assertEquals(1, secondExperimentRegions.length())
+        assertEquals("deu", secondExperimentRegions[0])
+        assertEquals("^org.mozilla.firefox${'$'}", secondExperimentMatch.getString("appId"))
+        assertEquals("es|deu", secondExperimentMatch.getString("lang"))
+        assertEquals("SecondDescription", secondExperiment.getString("description"))
+        assertEquals("experiment-2-id", secondExperiment.getString("id"))
+        assertEquals(1523549895749, secondExperiment.getLong("last_modified"))
     }
 
     @Test
     fun testToJsonEmptyList() {
         val experiments = listOf<Experiment>()
-        assertEquals("""{"experiments":[]}""", ExperimentsSerializer().toJson(experiments))
+        val experimentsJson = JSONObject(ExperimentsSerializer().toJson(experiments))
+        assertEquals(1, experimentsJson.length())
+        val experimentsJsonArray = experimentsJson.getJSONArray("experiments")
+        assertEquals(0, experimentsJsonArray.length())
     }
 }


### PR DESCRIPTION
When converting an experiment to json, don't check the json string. Instead, check the properties and their values in order to not depend on order.

Closes #32 