### PR TITLE
Issue #37: Add "export TERM=dumb" to taskcluster script

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -33,7 +33,8 @@ tasks:
         - '--login'
         - '-cx'
         - >-
-          mkdir -p /build/fretboard
+          export TERM=dumb
+          && mkdir -p /build/fretboard
           && cd /build/fretboard
           && git clone {{ event.head.repo.url }}
           && cd fretboard


### PR DESCRIPTION
Used to avoid gradle fancy progress bars on taskcluster logs, as discussed in mozilla-mobile/android-components#277

Closes #37 