### PR TITLE
Issue #41: Add test for IOException on HttpURLConnectionHttpClient

### DIFF
--- a/fretboard-client-kinto/src/test/java/mozilla/components/service/fretboard/source/kinto/HttpURLConnectionHttpClientTest.kt
+++ b/fretboard-client-kinto/src/test/java/mozilla/components/service/fretboard/source/kinto/HttpURLConnectionHttpClientTest.kt
@@ -12,9 +12,21 @@ import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
+import java.net.URL
 
 @RunWith(RobolectricTestRunner::class)
 class HttpURLConnectionHttpClientTest {
+    @Test(expected = ExperimentDownloadException::class)
+    fun testGETIOException() {
+        val server = MockWebServer()
+        try {
+            val serverUrl = server.url("/").url().toString()
+            HttpURLConnectionHttpClient().get(URL(serverUrl.replace(server.port.toString(), (server.port + 1).toString())))
+        } finally {
+            server.shutdown()
+        }
+    }
+
     @Test(expected = ExperimentDownloadException::class)
     fun testGET404() {
         testGETError(404)


### PR DESCRIPTION
This pull requests adds a test for checking that `HttpURLConnectionHttpClient` throws an `ExperimentDownloadException` when an `IOException` gets thrown.

Closes #41