### PR TITLE
Issue #15: Certificate pinning

### DIFF
--- a/fretboard-client-kinto/build.gradle
+++ b/fretboard-client-kinto/build.gradle
@@ -11,6 +11,8 @@ android {
     defaultConfig {
         minSdkVersion rootProject.ext.build['minSdkVersion']
         targetSdkVersion rootProject.ext.build['targetSdkVersion']
+
+        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
 
     lintOptions {
@@ -35,4 +37,12 @@ dependencies {
     testImplementation "org.robolectric:robolectric:${rootProject.ext.dependencies['robolectric']}"
     testImplementation "org.mockito:mockito-core:${rootProject.ext.dependencies['mockito']}"
     testImplementation "com.squareup.okhttp3:mockwebserver:${rootProject.ext.dependencies['mockwebserver']}"
+    androidTestImplementation "com.android.support.test:runner:${rootProject.ext.dependencies['runner']}"
+    androidTestImplementation "com.android.support:support-annotations:${rootProject.ext.dependencies['annotations']}"
+    androidTestImplementation "com.squareup.okhttp3:mockwebserver:${rootProject.ext.dependencies['mockwebserver']}"
+    // force use BouncyCastle 1.50 to avoid problems with MockWebServer, see https://github.com/square/okhttp/issues/3672
+    // noinspection GradleDependency
+    androidTestImplementation ("org.bouncycastle:bcprov-jdk15on:1.50") {
+        force = true
+    }
 }

--- a/fretboard-client-kinto/src/androidTest/AndroidManifest.xml
+++ b/fretboard-client-kinto/src/androidTest/AndroidManifest.xml
@@ -1,0 +1,7 @@
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="mozilla.components.service.fretboard.source.kinto">
+    <uses-permission android:name="android.permission.INTERNET" />
+</manifest>

--- a/fretboard-client-kinto/src/androidTest/java/mozilla/components/service/fretboard/source/kinto/CertificatePinnerTest.kt
+++ b/fretboard-client-kinto/src/androidTest/java/mozilla/components/service/fretboard/source/kinto/CertificatePinnerTest.kt
@@ -1,0 +1,75 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import android.support.test.runner.AndroidJUnit4
+import android.util.Base64
+import mozilla.components.service.fretboard.source.kinto.CertificatePinner
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import okhttp3.mockwebserver.internal.tls.SslClient
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.security.MessageDigest
+import javax.net.ssl.HttpsURLConnection
+
+@RunWith(AndroidJUnit4::class)
+class CertificatePinnerTest {
+    @Test
+    fun testCheckCertificatePinningNoPins() {
+        val server = MockWebServer()
+        server.useHttps(SslClient.localhost().socketFactory, false)
+        server.enqueue(MockResponse().setBody("B"))
+        HttpsURLConnection.setDefaultSSLSocketFactory(SslClient.localhost().socketFactory)
+        HttpsURLConnection.setDefaultHostnameVerifier { hostname, session -> true }
+        val connection = server.url("/").url().openConnection() as HttpsURLConnection
+        connection.connect()
+        assertTrue(CertificatePinner().checkCertificatePinning(connection, setOf()))
+    }
+
+    @Test()
+    fun testCheckCertificatePinningBadPin() {
+        val server = MockWebServer()
+        server.useHttps(SslClient.localhost().socketFactory, false)
+        server.enqueue(MockResponse().setBody("B"))
+        HttpsURLConnection.setDefaultSSLSocketFactory(SslClient.localhost().socketFactory)
+        HttpsURLConnection.setDefaultHostnameVerifier { hostname, session -> true }
+        val connection = server.url("/").url().openConnection() as HttpsURLConnection
+        connection.connect()
+        assertFalse(CertificatePinner().checkCertificatePinning(connection, setOf("b"), arrayOf(SslClient.localhost().trustManager)))
+    }
+
+    @Test
+    fun testCheckCertificatePinningGoodPin() {
+        val server = MockWebServer()
+        server.useHttps(SslClient.localhost().socketFactory, false)
+        server.enqueue(MockResponse().setBody("B"))
+        HttpsURLConnection.setDefaultSSLSocketFactory(SslClient.localhost().socketFactory)
+        HttpsURLConnection.setDefaultHostnameVerifier { hostname, session -> true }
+        val connection = server.url("/").url().openConnection() as HttpsURLConnection
+        connection.connect()
+        val certificatePublicKey = connection.serverCertificates[0].publicKey.encoded
+        val digest = MessageDigest.getInstance("SHA-256")
+        digest.update(certificatePublicKey)
+        val pin = Base64.encodeToString(digest.digest(), Base64.NO_WRAP)
+        assertTrue(CertificatePinner().checkCertificatePinning(connection, setOf(pin), arrayOf(SslClient.localhost().trustManager)))
+    }
+
+    @Test
+    fun testCheckCertificatePinningBadCertificate() {
+        val server = MockWebServer()
+        server.useHttps(SslClient.localhost().socketFactory, false)
+        server.enqueue(MockResponse().setBody("B"))
+        HttpsURLConnection.setDefaultSSLSocketFactory(SslClient.localhost().socketFactory)
+        HttpsURLConnection.setDefaultHostnameVerifier { hostname, session -> true }
+        val connection = server.url("/").url().openConnection() as HttpsURLConnection
+        connection.connect()
+        val certificatePublicKey = connection.serverCertificates[0].publicKey.encoded
+        val digest = MessageDigest.getInstance("SHA-256")
+        digest.update(certificatePublicKey)
+        val pin = Base64.encodeToString(digest.digest(), Base64.NO_WRAP)
+        assertFalse(CertificatePinner().checkCertificatePinning(connection, setOf(pin)))
+    }
+}

--- a/fretboard-client-kinto/src/main/java/mozilla/components/service/fretboard/source/kinto/CertificatePinner.kt
+++ b/fretboard-client-kinto/src/main/java/mozilla/components/service/fretboard/source/kinto/CertificatePinner.kt
@@ -1,0 +1,67 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.service.fretboard.source.kinto
+
+import android.net.http.X509TrustManagerExtensions
+import android.util.Base64
+import java.security.KeyStore
+import java.security.MessageDigest
+import java.security.cert.CertificateException
+import java.security.cert.X509Certificate
+import javax.net.ssl.HttpsURLConnection
+import javax.net.ssl.SSLException
+import javax.net.ssl.TrustManager
+import javax.net.ssl.TrustManagerFactory
+import javax.net.ssl.X509TrustManager
+
+internal class CertificatePinner {
+    internal fun checkCertificatePinning(
+        connection: HttpsURLConnection,
+        pinnedKeys: Set<String>,
+        trustManagers: Array<TrustManager> = defaultTrustManagers()
+    ): Boolean {
+        if (pinnedKeys.isEmpty()) {
+            return true
+        }
+        val trustManager = trustManagers.first { it is X509TrustManager } as X509TrustManager
+        val trustManagerExtensions = X509TrustManagerExtensions(trustManager)
+        val shaDigest = MessageDigest.getInstance("SHA-256")
+        return try {
+            val trustedChain = getTrustedChain(trustManagerExtensions, connection)
+            trustedChain.any { checkPinnedCertificates(it, shaDigest, pinnedKeys) }
+        } catch (e: SSLException) {
+            false
+        }
+    }
+
+    private fun defaultTrustManagers(): Array<TrustManager> {
+        val trustManagerFactory = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm())
+        trustManagerFactory.init(null as KeyStore?)
+        return trustManagerFactory.trustManagers
+    }
+
+    private fun getTrustedChain(
+        trustManagerExtensions: X509TrustManagerExtensions,
+        connection: HttpsURLConnection
+    ): List<X509Certificate> {
+        val serverCertificates = connection.serverCertificates.map { it as X509Certificate }.toTypedArray()
+        try {
+            return trustManagerExtensions.checkServerTrusted(serverCertificates, "RSA", connection.url.host)
+        } catch (e: CertificateException) {
+            throw SSLException(e)
+        }
+    }
+
+    private fun checkPinnedCertificates(
+        certificate: X509Certificate,
+        digest: MessageDigest,
+        pinnedKeys: Set<String>
+    ): Boolean {
+        val publicKey = certificate.publicKey.encoded
+        digest.update(publicKey)
+        val pin = Base64.encodeToString(digest.digest(), Base64.NO_WRAP)
+        return pinnedKeys.contains(pin)
+    }
+}

--- a/fretboard-client-kinto/src/main/java/mozilla/components/service/fretboard/source/kinto/HttpClient.kt
+++ b/fretboard-client-kinto/src/main/java/mozilla/components/service/fretboard/source/kinto/HttpClient.kt
@@ -21,4 +21,11 @@ interface HttpClient {
      * @return HTTP response
      */
     fun get(url: URL, headers: Map<String, String>? = null): String
+
+    /**
+     * Enables certificate pinning using the provided keys
+     *
+     * @keys set of base64 encoded SHA-256 certificate subject public key info hashes
+     */
+    fun pinCertificates(keys: Set<String>)
 }

--- a/fretboard-client-kinto/src/main/java/mozilla/components/service/fretboard/source/kinto/KintoExperimentSource.kt
+++ b/fretboard-client-kinto/src/main/java/mozilla/components/service/fretboard/source/kinto/KintoExperimentSource.kt
@@ -29,6 +29,10 @@ class KintoExperimentSource(
         return mergeExperimentsFromDiff(experimentsDiff, experiments)
     }
 
+    override fun pinCertificates(keys: Set<String>) {
+        client.pinCertificates(keys)
+    }
+
     private fun getExperimentsDiff(client: HttpClient, experiments: List<Experiment>): String {
         val lastModified = getMaxLastModified(experiments)
         val kintoClient = KintoClient(client, baseUrl, bucketName, collectionName)

--- a/fretboard-client-kinto/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/fretboard-client-kinto/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline

--- a/fretboard-storage-flatfile/src/androidTest/java/mozilla/components/service/fretboard/storage/atomicfile/AtomicFileExperimentStorageTest.kt
+++ b/fretboard-storage-flatfile/src/androidTest/java/mozilla/components/service/fretboard/storage/atomicfile/AtomicFileExperimentStorageTest.kt
@@ -9,9 +9,9 @@ import android.support.test.runner.AndroidJUnit4
 import android.util.AtomicFile
 import mozilla.components.service.fretboard.Experiment
 import org.json.JSONObject
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
-import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.junit.runner.RunWith
 import java.io.File

--- a/fretboard/src/main/java/mozilla/components/service/fretboard/ExperimentSource.kt
+++ b/fretboard/src/main/java/mozilla/components/service/fretboard/ExperimentSource.kt
@@ -19,4 +19,11 @@ interface ExperimentSource {
      * @return modified list of experiments
      */
     fun getExperiments(experiments: List<Experiment>): List<Experiment>
+
+    /**
+     * Enables certificate pinning using the provided keys
+     *
+     * @keys set of base64 encoded SHA-256 certificate subject public key info hashes
+     */
+    fun pinCertificates(keys: Set<String>)
 }


### PR DESCRIPTION
This pull request introduces certificate pinning. It adds a `pinCertificates` method to `ExperimentSource` with a set of base64-encoded SHA-256 of the certificate subject public key info.

The implementation first gets the list of trusted certificates as detailed, cleaning the certificate chain using `X509TrustManagerExtensions` as described [here](https://www.synopsys.com/blogs/software-security/ineffective-certificate-pinning-implementations/) and [here](https://medium.com/@appmattus/android-security-ssl-pinning-1db8acb6621e).

I also discovered there are libraries available such as `TrustKit` which replicate the behavior of Android N+ Network Security Configuration, but I decided against using it because it adds extra bloat to the library and also the user has to create an XML file and register it on the Manifest, I don't know if you have a different opinion.

Closes #15