### PR TITLE
Issue #50: Make FlatFileExperimentStorage receive a File

### DIFF
--- a/fretboard-storage-flatfile/src/main/java/mozilla/components/service/fretboard/storage/atomicfile/FlatFileExperimentStorage.kt
+++ b/fretboard-storage-flatfile/src/main/java/mozilla/components/service/fretboard/storage/atomicfile/FlatFileExperimentStorage.kt
@@ -8,8 +8,11 @@ import android.util.AtomicFile
 import mozilla.components.service.fretboard.Experiment
 import mozilla.components.service.fretboard.ExperimentStorage
 import java.io.FileNotFoundException
+import java.io.File
 
-class FlatFileExperimentStorage(private val atomicFile: AtomicFile) : ExperimentStorage {
+class FlatFileExperimentStorage(file: File) : ExperimentStorage {
+    private val atomicFile: AtomicFile = AtomicFile(file)
+
     override fun retrieve(): List<Experiment> {
         try {
             val experimentsJson = String(atomicFile.readFully())


### PR DESCRIPTION
This pull request makes `FlatFileExperimentStorage` receive a `File` instead of an `AtomicFile`. Turns out I didn't modify it while renaming the class.

Closes #50