### PR TITLE
Issue #48: Kinto delete diffs might lead to crash

### DIFF
--- a/fretboard-client-kinto/src/main/java/mozilla/components/service/fretboard/source/kinto/KintoExperimentSource.kt
+++ b/fretboard-client-kinto/src/main/java/mozilla/components/service/fretboard/source/kinto/KintoExperimentSource.kt
@@ -4,9 +4,9 @@
 
 package mozilla.components.service.fretboard.source.kinto
 
-import mozilla.components.service.fretboard.Experiment
 import mozilla.components.service.fretboard.ExperimentSource
 import mozilla.components.service.fretboard.JSONExperimentParser
+import mozilla.components.service.fretboard.SyncResult
 import org.json.JSONArray
 import org.json.JSONObject
 
@@ -24,13 +24,13 @@ class KintoExperimentSource(
     val collectionName: String,
     private val client: HttpClient = HttpURLConnectionHttpClient()
 ) : ExperimentSource {
-    override fun getExperiments(experiments: List<Experiment>): List<Experiment> {
-        val experimentsDiff = getExperimentsDiff(client, experiments)
-        return mergeExperimentsFromDiff(experimentsDiff, experiments)
+    override fun getExperiments(syncResult: SyncResult): SyncResult {
+        val experimentsDiff = getExperimentsDiff(client, syncResult)
+        return mergeExperimentsFromDiff(experimentsDiff, syncResult)
     }
 
-    private fun getExperimentsDiff(client: HttpClient, experiments: List<Experiment>): String {
-        val lastModified = getMaxLastModified(experiments)
+    private fun getExperimentsDiff(client: HttpClient, syncResult: SyncResult): String {
+        val lastModified = syncResult.lastModified
         val kintoClient = KintoClient(client, baseUrl, bucketName, collectionName)
         return if (lastModified != null) {
             kintoClient.diff(lastModified)
@@ -39,53 +39,35 @@ class KintoExperimentSource(
         }
     }
 
-    private fun mergeExperimentsFromDiff(experimentsDiff: String, experiments: List<Experiment>): List<Experiment> {
+    private fun mergeExperimentsFromDiff(experimentsDiff: String, syncResult: SyncResult): SyncResult {
+        val experiments = syncResult.experiments
         val mutableExperiments = experiments.toMutableList()
         val experimentParser = JSONExperimentParser()
         val diffJsonObject = JSONObject(experimentsDiff)
         val data = diffJsonObject.get(DATA_KEY)
-        if (data is JSONObject) {
-            if (data.getBoolean(DELETED_KEY)) {
-                mergeDeleteDiff(data, mutableExperiments)
-            }
-        } else {
-            mergeAddUpdateDiff(experimentParser, data as JSONArray, mutableExperiments)
-        }
-        return mutableExperiments
-    }
-
-    private fun mergeDeleteDiff(data: JSONObject, mutableExperiments: MutableList<Experiment>) {
-        mutableExperiments.remove(mutableExperiments.single { it.id == data.getString(ID_KEY) })
-    }
-
-    private fun mergeAddUpdateDiff(
-        experimentParser: JSONExperimentParser,
-        experimentsJsonArray: JSONArray,
-        mutableExperiments: MutableList<Experiment>
-    ) {
+        val experimentsJsonArray = data as JSONArray
+        var maxLastModified: Long? = syncResult.lastModified
         for (i in 0 until experimentsJsonArray.length()) {
             val experimentJsonObject = experimentsJsonArray[i] as JSONObject
             val experiment = mutableExperiments.singleOrNull { it.id == experimentJsonObject.getString(ID_KEY) }
-            if (experiment != null)
+            if (experiment != null) {
                 mutableExperiments.remove(experiment)
-            mutableExperiments.add(experimentParser.fromJson(experimentJsonObject))
-        }
-    }
-
-    private fun getMaxLastModified(experiments: List<Experiment>): Long? {
-        var maxLastModified: Long = -1
-        for (experiment in experiments) {
-            val lastModified = experiment.lastModified
-            if (lastModified != null && lastModified > maxLastModified) {
-                maxLastModified = lastModified
+            }
+            if (!experimentJsonObject.has(DELETED_KEY)) {
+                mutableExperiments.add(experimentParser.fromJson(experimentJsonObject))
+            }
+            val lastModifiedDate = experimentJsonObject.getLong(LAST_MODIFIED_KEY)
+            if (maxLastModified == null || lastModifiedDate > maxLastModified) {
+                maxLastModified = lastModifiedDate
             }
         }
-        return if (maxLastModified > 0) maxLastModified else null
+        return SyncResult(mutableExperiments, maxLastModified)
     }
 
     companion object {
         private const val ID_KEY = "id"
         private const val DATA_KEY = "data"
         private const val DELETED_KEY = "deleted"
+        private const val LAST_MODIFIED_KEY = "last_modified"
     }
 }

--- a/fretboard-client-kinto/src/test/java/mozilla/components/service/fretboard/source/kinto/KintoExperimentSourceTest.kt
+++ b/fretboard-client-kinto/src/test/java/mozilla/components/service/fretboard/source/kinto/KintoExperimentSourceTest.kt
@@ -5,7 +5,9 @@
 package mozilla.components.service.fretboard.source.kinto
 
 import mozilla.components.service.fretboard.Experiment
+import mozilla.components.service.fretboard.SyncResult
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.`when`
@@ -26,7 +28,9 @@ class KintoExperimentSourceTest {
         `when`(httpClient.get(URL("$baseUrl/buckets/$bucketName/collections/$collectionName/records")))
             .thenReturn("""{"data":[]}""")
         val experimentSource = KintoExperimentSource(baseUrl, bucketName, collectionName, httpClient)
-        assertEquals(0, experimentSource.getExperiments(listOf()).size)
+        val result = experimentSource.getExperiments(SyncResult(listOf(), null))
+        assertEquals(0, result.experiments.size)
+        assertNull(result.lastModified)
     }
 
     @Test
@@ -45,9 +49,10 @@ class KintoExperimentSourceTest {
         )
 
         val experimentSource = KintoExperimentSource(baseUrl, bucketName, collectionName, httpClient)
-        val kintoExperiments = experimentSource.getExperiments(listOf())
-        assertEquals(1, kintoExperiments.size)
-        assertEquals(expectedExperiment, kintoExperiments[0])
+        val kintoExperiments = experimentSource.getExperiments(SyncResult(listOf(), null))
+        assertEquals(1, kintoExperiments.experiments.size)
+        assertEquals(expectedExperiment, kintoExperiments.experiments[0])
+        assertEquals(1523549895713, kintoExperiments.lastModified)
     }
 
     @Test
@@ -73,17 +78,20 @@ class KintoExperimentSourceTest {
         )
 
         val experimentSource = KintoExperimentSource(baseUrl, bucketName, collectionName, httpClient)
-        val kintoExperiments = experimentSource.getExperiments(listOf(storageExperiment))
-        assertEquals(2, kintoExperiments.size)
-        assertEquals(storageExperiment, kintoExperiments[0])
-        assertEquals(kintoExperiment, kintoExperiments[1])
+        val kintoExperiments = experimentSource.getExperiments(SyncResult(listOf(storageExperiment), 1523549890000))
+        assertEquals(2, kintoExperiments.experiments.size)
+        assertEquals(storageExperiment, kintoExperiments.experiments[0])
+        assertEquals(kintoExperiment, kintoExperiments.experiments[1])
+        assertEquals(1523549895713, kintoExperiments.lastModified)
     }
 
     @Test
     fun testGetExperimentsDiffDelete() {
         val httpClient = mock(HttpClient::class.java)
         `when`(httpClient.get(URL("$baseUrl/buckets/$bucketName/collections/$collectionName/records?_since=1523549890000")))
-            .thenReturn("""{"data":{"deleted":true,"id":"id","last_modified":1523549899999}}""")
+            .thenReturn("""{"data":[{"deleted":true,"id":"id","last_modified":1523549899999}]}""")
+        `when`(httpClient.get(URL("$baseUrl/buckets/$bucketName/collections/$collectionName/records?_since=1523549899999")))
+            .thenReturn("""{"data":[]}""")
 
         val storageExperiment = Experiment("id",
             "name",
@@ -93,9 +101,20 @@ class KintoExperimentSourceTest {
             1523549890000
         )
 
+        val secondExperiment = Experiment("id2",
+            "name2",
+            "description2",
+            Experiment.Matcher("eng", "appId", listOf("US")),
+            Experiment.Bucket(10, 5),
+            1523549890000)
+
         val experimentSource = KintoExperimentSource(baseUrl, bucketName, collectionName, httpClient)
-        val kintoExperiments = experimentSource.getExperiments(listOf(storageExperiment))
-        assertEquals(0, kintoExperiments.size)
+        val kintoExperiments = experimentSource.getExperiments(SyncResult(listOf(storageExperiment, secondExperiment), 1523549890000))
+        assertEquals(1, kintoExperiments.experiments.size)
+        assertEquals(1523549899999, kintoExperiments.lastModified)
+        val experimentsResult = experimentSource.getExperiments(SyncResult(kintoExperiments.experiments, 1523549899999))
+        assertEquals(1, experimentsResult.experiments.size)
+        assertEquals(1523549899999, experimentsResult.lastModified)
     }
 
     @Test
@@ -121,9 +140,10 @@ class KintoExperimentSourceTest {
         )
 
         val experimentSource = KintoExperimentSource(baseUrl, bucketName, collectionName, httpClient)
-        val kintoExperiments = experimentSource.getExperiments(listOf(storageExperiment))
-        assertEquals(1, kintoExperiments.size)
-        assertEquals(kintoExperiment, kintoExperiments[0])
+        val kintoExperiments = experimentSource.getExperiments(SyncResult(listOf(storageExperiment), 1523549800000))
+        assertEquals(1, kintoExperiments.experiments.size)
+        assertEquals(kintoExperiment, kintoExperiments.experiments[0])
+        assertEquals(1523549895713, kintoExperiments.lastModified)
     }
 
     @Test
@@ -141,8 +161,9 @@ class KintoExperimentSourceTest {
         )
 
         val experimentSource = KintoExperimentSource(baseUrl, bucketName, collectionName, httpClient)
-        val kintoExperiments = experimentSource.getExperiments(listOf(storageExperiment))
-        assertEquals(1, kintoExperiments.size)
-        assertEquals(storageExperiment, kintoExperiments[0])
+        val kintoExperiments = experimentSource.getExperiments(SyncResult(listOf(storageExperiment), 1523549895713))
+        assertEquals(1, kintoExperiments.experiments.size)
+        assertEquals(storageExperiment, kintoExperiments.experiments[0])
+        assertEquals(1523549895713, kintoExperiments.lastModified)
     }
 }

--- a/fretboard-storage-flatfile/src/androidTest/java/mozilla/components/service/fretboard/storage/flatfile/FlatFileExperimentStorageTest.kt
+++ b/fretboard-storage-flatfile/src/androidTest/java/mozilla/components/service/fretboard/storage/flatfile/FlatFileExperimentStorageTest.kt
@@ -7,9 +7,11 @@ package mozilla.components.service.fretboard.storage.flatfile
 import android.support.test.InstrumentationRegistry
 import android.support.test.runner.AndroidJUnit4
 import mozilla.components.service.fretboard.Experiment
+import mozilla.components.service.fretboard.SyncResult
 import org.json.JSONObject
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -31,7 +33,7 @@ class FlatFileExperimentStorageTest {
         )
         val file = File(InstrumentationRegistry.getContext().filesDir, "experiments.json")
         assertFalse(file.exists())
-        FlatFileExperimentStorage(file).save(experiments)
+        FlatFileExperimentStorage(file).save(SyncResult(experiments, 1526991669))
         assertTrue(file.exists())
         val experimentsJson = JSONObject(String(Files.readAllBytes(Paths.get(file.absolutePath))))
         checkSavedExperimentsJson(experimentsJson)
@@ -39,7 +41,7 @@ class FlatFileExperimentStorageTest {
     }
 
     private fun checkSavedExperimentsJson(experimentsJson: JSONObject) {
-        assertEquals(1, experimentsJson.length())
+        assertEquals(2, experimentsJson.length())
         val experimentsJsonArray = experimentsJson.getJSONArray("experiments")
         assertEquals(1, experimentsJsonArray.length())
         val experimentJson = experimentsJsonArray[0] as JSONObject
@@ -62,9 +64,10 @@ class FlatFileExperimentStorageTest {
     fun testRetrieve() {
         val file = File(InstrumentationRegistry.getContext().filesDir, "experiments.json")
         file.writer().use {
-            it.write("""{"experiments":[{"name":"sample-name","match":{"lang":"es|en","appId":"sample-appId","regions":["US"]},"buckets":{"max":20,"min":0},"description":"sample-description","id":"sample-id","last_modified":1526991669}]}""")
+            it.write("""{"experiments":[{"name":"sample-name","match":{"lang":"es|en","appId":"sample-appId","regions":["US"]},"buckets":{"max":20,"min":0},"description":"sample-description","id":"sample-id","last_modified":1526991669}],"last_modified":1526991669}""")
         }
-        val experiments = FlatFileExperimentStorage(file).retrieve()
+        val experimentsResult = FlatFileExperimentStorage(file).retrieve()
+        val experiments = experimentsResult.experiments
         file.delete()
         assertEquals(1, experiments.size)
         assertEquals("sample-id", experiments[0].id)
@@ -76,12 +79,14 @@ class FlatFileExperimentStorageTest {
         assertEquals(20, experiments[0].bucket?.max)
         assertEquals(0, experiments[0].bucket?.min)
         assertEquals(1526991669L, experiments[0].lastModified)
+        assertEquals(1526991669L, experimentsResult.lastModified)
     }
 
     @Test
     fun testRetrieveFileNotFound() {
         val file = File(InstrumentationRegistry.getContext().filesDir, "missingFile.json")
-        val experiments = FlatFileExperimentStorage(file).retrieve()
-        assertEquals(0, experiments.size)
+        val experimentsResult = FlatFileExperimentStorage(file).retrieve()
+        assertEquals(0, experimentsResult.experiments.size)
+        assertNull(experimentsResult.lastModified)
     }
 }

--- a/fretboard-storage-flatfile/src/main/java/mozilla/components/service/fretboard/storage/flatfile/ExperimentsSerializer.kt
+++ b/fretboard-storage-flatfile/src/main/java/mozilla/components/service/fretboard/storage/flatfile/ExperimentsSerializer.kt
@@ -6,6 +6,7 @@ package mozilla.components.service.fretboard.storage.flatfile
 
 import mozilla.components.service.fretboard.Experiment
 import mozilla.components.service.fretboard.JSONExperimentParser
+import mozilla.components.service.fretboard.SyncResult
 import org.json.JSONArray
 import org.json.JSONObject
 
@@ -19,16 +20,17 @@ internal class ExperimentsSerializer {
      * Transforms the given list of experiments to
      * its json file representation
      *
-     * @param experiments experiments to serialize
+     * @param syncResult experiments to serialize
      * @return json file representation of the given experiments
      */
-    fun toJson(experiments: List<Experiment>): String {
+    fun toJson(syncResult: SyncResult): String {
         val experimentsJson = JSONObject()
         val experimentsJSONArray = JSONArray()
         val jsonParser = JSONExperimentParser()
-        for (experiment in experiments)
+        for (experiment in syncResult.experiments)
             experimentsJSONArray.put(jsonParser.toJson(experiment))
         experimentsJson.put(EXPERIMENTS_KEY, experimentsJSONArray)
+        experimentsJson.put(LAST_MODIFIED_KEY, syncResult.lastModified)
         return experimentsJson.toString()
     }
 
@@ -39,16 +41,24 @@ internal class ExperimentsSerializer {
      * @param json json file contents
      * @return list of experiments
      */
-    fun fromJson(json: String): List<Experiment> {
-        val experimentsJsonArray = JSONObject(json).getJSONArray(EXPERIMENTS_KEY)
+    fun fromJson(json: String): SyncResult {
+        val experimentsJson = JSONObject(json)
+        val experimentsJsonArray = experimentsJson.getJSONArray(EXPERIMENTS_KEY)
         val experiments = ArrayList<Experiment>()
         val jsonParser = JSONExperimentParser()
         for (i in 0 until experimentsJsonArray.length())
             experiments.add(jsonParser.fromJson(experimentsJsonArray[i] as JSONObject))
-        return experiments
+        val lastModified: Long?
+        if (experimentsJson.has(LAST_MODIFIED_KEY)) {
+            lastModified = experimentsJson.getLong(LAST_MODIFIED_KEY)
+        } else {
+            lastModified = null
+        }
+        return SyncResult(experiments, lastModified)
     }
 
     companion object {
         private const val EXPERIMENTS_KEY = "experiments"
+        private const val LAST_MODIFIED_KEY = "last_modified"
     }
 }

--- a/fretboard-storage-flatfile/src/main/java/mozilla/components/service/fretboard/storage/flatfile/FlatFileExperimentStorage.kt
+++ b/fretboard-storage-flatfile/src/main/java/mozilla/components/service/fretboard/storage/flatfile/FlatFileExperimentStorage.kt
@@ -5,25 +5,25 @@
 package mozilla.components.service.fretboard.storage.flatfile
 
 import android.util.AtomicFile
-import mozilla.components.service.fretboard.Experiment
 import mozilla.components.service.fretboard.ExperimentStorage
+import mozilla.components.service.fretboard.SyncResult
 import java.io.FileNotFoundException
 import java.io.File
 
 class FlatFileExperimentStorage(file: File) : ExperimentStorage {
     private val atomicFile: AtomicFile = AtomicFile(file)
 
-    override fun retrieve(): List<Experiment> {
+    override fun retrieve(): SyncResult {
         try {
             val experimentsJson = String(atomicFile.readFully())
             return ExperimentsSerializer().fromJson(experimentsJson)
         } catch (e: FileNotFoundException) {
-            return listOf()
+            return SyncResult(listOf(), null)
         }
     }
 
-    override fun save(experiments: List<Experiment>) {
-        val experimentsJson = ExperimentsSerializer().toJson(experiments)
+    override fun save(syncResult: SyncResult) {
+        val experimentsJson = ExperimentsSerializer().toJson(syncResult)
         atomicFile.startWrite().writer().use {
             it.append(experimentsJson)
         }

--- a/fretboard-storage-flatfile/src/test/java/mozilla/components/service/fretboard/storage/flatfile/ExperimentsSerializerTest.kt
+++ b/fretboard-storage-flatfile/src/test/java/mozilla/components/service/fretboard/storage/flatfile/ExperimentsSerializerTest.kt
@@ -5,9 +5,11 @@
 package mozilla.components.service.fretboard.storage.flatfile
 
 import mozilla.components.service.fretboard.Experiment
+import mozilla.components.service.fretboard.SyncResult
 import org.json.JSONException
 import org.json.JSONObject
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -49,7 +51,8 @@ val experimentsJson = """
                                           "id":"experiment-2-id",
                                           "last_modified":1523549895749
                                       }
-                                  ]
+                                  ],
+                                  "last_modified": 1523549895749
                               }
                               """
 
@@ -57,7 +60,8 @@ val experimentsJson = """
 class ExperimentsSerializerTest {
     @Test
     fun testFromJsonValid() {
-        val experiments = ExperimentsSerializer().fromJson(experimentsJson)
+        val experimentsResult = ExperimentsSerializer().fromJson(experimentsJson)
+        val experiments = experimentsResult.experiments
         assertEquals(2, experiments.size)
         assertEquals("first", experiments[0].name)
         assertEquals("eng|es|deu|fra", experiments[0].match!!.language)
@@ -79,6 +83,7 @@ class ExperimentsSerializerTest {
         assertEquals("SecondDescription", experiments[1].description)
         assertEquals("experiment-2-id", experiments[1].id)
         assertEquals(1523549895749, experiments[1].lastModified)
+        assertEquals(1523549895749, experimentsResult.lastModified)
     }
 
     @Test(expected = JSONException::class)
@@ -89,7 +94,9 @@ class ExperimentsSerializerTest {
     @Test
     fun testFromJsonEmptyArray() {
         val experimentsJson = """ {"experiments":[]} """
-        assertEquals(0, ExperimentsSerializer().fromJson(experimentsJson).size)
+        val experimentsResult = ExperimentsSerializer().fromJson(experimentsJson)
+        assertEquals(0, experimentsResult.experiments.size)
+        assertNull(experimentsResult.lastModified)
     }
 
     @Test
@@ -108,8 +115,9 @@ class ExperimentsSerializerTest {
                 Experiment.Bucket(10, 5),
                 1523549895749)
         )
-        val json = JSONObject(ExperimentsSerializer().toJson(experiments))
-        assertEquals(1, json.length())
+        val json = JSONObject(ExperimentsSerializer().toJson(SyncResult(experiments, 1523549895749)))
+        assertEquals(2, json.length())
+        assertEquals(1523549895749, json.getLong("last_modified"))
         val experimentsArray = json.getJSONArray("experiments")
         assertEquals(2, experimentsArray.length())
         val firstExperiment = experimentsArray[0] as JSONObject
@@ -146,7 +154,7 @@ class ExperimentsSerializerTest {
     @Test
     fun testToJsonEmptyList() {
         val experiments = listOf<Experiment>()
-        val experimentsJson = JSONObject(ExperimentsSerializer().toJson(experiments))
+        val experimentsJson = JSONObject(ExperimentsSerializer().toJson(SyncResult(experiments, null)))
         assertEquals(1, experimentsJson.length())
         val experimentsJsonArray = experimentsJson.getJSONArray("experiments")
         assertEquals(0, experimentsJsonArray.length())

--- a/fretboard/src/main/java/mozilla/components/service/fretboard/ExperimentSource.kt
+++ b/fretboard/src/main/java/mozilla/components/service/fretboard/ExperimentSource.kt
@@ -14,9 +14,9 @@ interface ExperimentSource {
      * parsing the response into experiments
      *
      * @param client Http client to use, provided by Fretboard
-     * @param experiments list of already downloaded experiments
+     * @param syncResult list of already downloaded experiments
      * (in order to process a diff response, for example)
      * @return modified list of experiments
      */
-    fun getExperiments(experiments: List<Experiment>): List<Experiment>
+    fun getExperiments(syncResult: SyncResult): SyncResult
 }

--- a/fretboard/src/main/java/mozilla/components/service/fretboard/ExperimentStorage.kt
+++ b/fretboard/src/main/java/mozilla/components/service/fretboard/ExperimentStorage.kt
@@ -14,12 +14,12 @@ interface ExperimentStorage {
      *
      * @param experiments list of experiments to store
      */
-    fun save(experiments: List<Experiment>)
+    fun save(syncResult: SyncResult)
 
     /**
      * Reads experiments from disk
      *
      * @return experiments from disk
      */
-    fun retrieve(): List<Experiment>
+    fun retrieve(): SyncResult
 }

--- a/fretboard/src/main/java/mozilla/components/service/fretboard/Fretboard.kt
+++ b/fretboard/src/main/java/mozilla/components/service/fretboard/Fretboard.kt
@@ -17,7 +17,7 @@ class Fretboard(
     private val storage: ExperimentStorage,
     regionProvider: RegionProvider? = null
 ) {
-    private var experiments: List<Experiment> = listOf()
+    private var experimentsResult: SyncResult = SyncResult(listOf(), null)
     private var experimentsLoaded: Boolean = false
     private val evaluator = ExperimentEvaluator(regionProvider)
 
@@ -26,7 +26,7 @@ class Fretboard(
      */
     @Synchronized
     fun loadExperiments() {
-        experiments = storage.retrieve()
+        experimentsResult = storage.retrieve()
         experimentsLoaded = true
     }
 
@@ -40,8 +40,8 @@ class Fretboard(
             loadExperiments()
         }
         try {
-            val serverExperiments = source.getExperiments(experiments)
-            experiments = serverExperiments
+            val serverExperiments = source.getExperiments(experimentsResult)
+            experimentsResult = serverExperiments
             storage.save(serverExperiments)
         } catch (e: ExperimentDownloadException) {
             // Keep using the local experiments
@@ -58,7 +58,7 @@ class Fretboard(
      * @return true if the user is part of the specified experiment, false otherwise
      */
     fun isInExperiment(context: Context, descriptor: ExperimentDescriptor): Boolean {
-        return evaluator.evaluate(context, descriptor, experiments) != null
+        return evaluator.evaluate(context, descriptor, experimentsResult.experiments) != null
     }
 
     /**
@@ -69,7 +69,7 @@ class Fretboard(
      * @param block block of code to be executed if the user is part of the experiment
      */
     fun withExperiment(context: Context, descriptor: ExperimentDescriptor, block: (Experiment) -> Unit) {
-        evaluator.evaluate(context, descriptor, experiments)?.let { block(it) }
+        evaluator.evaluate(context, descriptor, experimentsResult.experiments)?.let { block(it) }
     }
 
     /**
@@ -80,7 +80,7 @@ class Fretboard(
      * @return metadata associated with the experiment
      */
     fun getExperiment(descriptor: ExperimentDescriptor): Experiment? {
-        return evaluator.getExperiment(descriptor, experiments)
+        return evaluator.getExperiment(descriptor, experimentsResult.experiments)
     }
 
     /**

--- a/fretboard/src/main/java/mozilla/components/service/fretboard/SyncResult.kt
+++ b/fretboard/src/main/java/mozilla/components/service/fretboard/SyncResult.kt
@@ -1,0 +1,13 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.service.fretboard
+
+/**
+ * Represents an experiment sync result
+ */
+data class SyncResult(
+    val experiments: List<Experiment>,
+    val lastModified: Long?
+)

--- a/fretboard/src/test/java/mozilla/components/service/fretboard/FretboardTest.kt
+++ b/fretboard/src/test/java/mozilla/components/service/fretboard/FretboardTest.kt
@@ -6,7 +6,6 @@ package mozilla.components.service.fretboard
 
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mockito.ArgumentMatchers
 import org.mockito.Mockito.`when`
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.times
@@ -38,23 +37,25 @@ class FretboardTest {
     @Test
     fun testUpdateExperimentsEmptyStorage() {
         val experimentSource = mock(ExperimentSource::class.java)
-        `when`(experimentSource.getExperiments(ArgumentMatchers.anyList())).thenReturn(listOf(Experiment("id")))
+        val result = SyncResult(listOf(), null)
+        `when`(experimentSource.getExperiments(result)).thenReturn(SyncResult(listOf(Experiment("id")), null))
         val experimentStorage = mock(ExperimentStorage::class.java)
+        `when`(experimentStorage.retrieve()).thenReturn(result)
         val fretboard = Fretboard(experimentSource, experimentStorage)
         fretboard.updateExperiments()
-        verify(experimentSource).getExperiments(listOf())
-        verify(experimentStorage).save(listOf(Experiment("id")))
+        verify(experimentSource).getExperiments(result)
+        verify(experimentStorage).save(SyncResult(listOf(Experiment("id")), null))
     }
 
     @Test
     fun testUpdateExperimentsFromStorage() {
         val experimentSource = mock(ExperimentSource::class.java)
-        `when`(experimentSource.getExperiments(ArgumentMatchers.anyList())).thenReturn(listOf(Experiment("id")))
+        `when`(experimentSource.getExperiments(SyncResult(listOf(Experiment("id0")), null))).thenReturn(SyncResult(listOf(Experiment("id")), null))
         val experimentStorage = mock(ExperimentStorage::class.java)
-        `when`(experimentStorage.retrieve()).thenReturn(listOf(Experiment("id0")))
+        `when`(experimentStorage.retrieve()).thenReturn(SyncResult(listOf(Experiment("id0")), null))
         val fretboard = Fretboard(experimentSource, experimentStorage)
         fretboard.updateExperiments()
-        verify(experimentSource).getExperiments(listOf(Experiment("id0")))
-        verify(experimentStorage).save(listOf(Experiment("id")))
+        verify(experimentSource).getExperiments(SyncResult(listOf(Experiment("id0")), null))
+        verify(experimentStorage).save(SyncResult(listOf(Experiment("id")), null))
     }
 }


### PR DESCRIPTION
Previously, the last modified date was calculated as the max of the updated list of experiments (thus not including deleted items). This caused a problem where we'd be downloading delete diffs multiple times, with the associated data costs to the users, and also because the deleted experiment doesn't exist anymore, it could lead to a crash.

This pull request solves this, and instead of keeping around deleted experiments (maybe flagging them with a `deleted` attributed), with the associated memory and disk costs of this, I modified the signature of `ExperimentSource` and `ExperimentSource` from `List<Experiment>` to a `SyncResult` object, a class which contains a list of experiments and their associated last modified date.

Closes #48 